### PR TITLE
Added .RData and *.Rproj rules to R.gitignore

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -1,12 +1,15 @@
 # History files
 .Rhistory
 .Rapp.history
+.RData
 
 # Example code in package build process
 *-Ex.R
 
 # RStudio files
 .Rproj.user/
+*.Rproj
+
 
 # produced vignettes
 vignettes/*.html


### PR DESCRIPTION
.RData file is often saved on exiting an R session as an image of the workspace.
*.Rproj is the extension used by RStudio projects.
